### PR TITLE
Suggest adding MIT license

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2011-2012 Alex Sharp
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ EM::StatHat.new.ez_value('some metric', 123)
 
 * [stathat](https://github.com/patrickxb/stathat)
 * [em-http-request](https://github.com/igrigorik/em-http-request).
+
+## Copyright
+
+Copyright (c) 2011-2012 Alex Sharp. See the MIT-LICENSE file for full
+copyright information.

--- a/em-stathat.gemspec
+++ b/em-stathat.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/ajsharp/em-stathat"
   s.summary     = %q{An EventMachine-compatible async wrapper for the stathat api.}
   s.description = %q{Essentially a clone of the normal stathat gem, only for use with EventMachine.}
+  s.license     = "MIT"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec,features}/*`.split("\n")


### PR DESCRIPTION
Hi @ajsharp, I know this repo hasn't seen any activity in a few years, but the gem is being used, at least for a project that I'm auditing dependencies for. Would you mind adding a license to the repo so it is unambiguous that others have [copyright permission](http://choosealicense.com/no-license/) to use the gem?

I see that you're using MIT in https://github.com/ajsharp/bldr so I copied the style used there in making this PR. I don't care whether you use this PR but would really appreciate if you could add a license to the repo. Thanks in advance! 😄 

Also, to be clear, no need to cut a new version of the gem, unless you want to go through the trouble to have the license appear on https://rubygems.org/gems/em-stathat/ which might be slightly helpful to anyone looking at this in the future.
